### PR TITLE
Kubernetes agent docs

### DIFF
--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -1,10 +1,10 @@
 ---
 id: kubernetes_agent
-title: Kubernetes (Vantage Agent)
+title: Vantage Kubernetes Agent
 description: This page walks through how to connect the Vantage Kubernetes agent with your Kubernetes cluster.
 ---
 
-# Kubernetes (Vantage Agent)
+# Vantage Kubernetes Agent
 
 :::note Beta
 The Vantage Kubernetes agent is currently in Beta.
@@ -14,25 +14,23 @@ The Vantage Kubernetes agent is the default, recommended configuration to ingest
 
 ## Agent Functionality 
 
-The Vantage agent relies on native Kubernetes APIs, such as `kube-apiserver` for metadata and `kubelet` for container data. Access to these APIs is controlled via Kubernetes RBAC using a Service Account and ClusterRole, included in the Vantage [Kubernetes Agent Helm chart](https://github.com/vantage-sh/helm-charts). 
+The Vantage Kubernetes agent relies on native Kubernetes APIs, such as `kube-apiserver` for metadata and `kubelet` for container data. Access to these APIs is controlled via Kubernetes RBAC using a Service Account and ClusterRole, included in the Vantage [Kubernetes Agent Helm chart](https://github.com/vantage-sh/helm-charts). 
 
-Data is periodically collected and stored for aggregation, then sent directly to Vantage service through an API with your Vantage API token for authentication, which avoids extra storage costs. This architecture eliminates the need for deploying OpenCost-specific Prometheus pods, making scaling easier. 
+Data is periodically collected and stored for aggregation, then sent directly to the Vantage service through an API, with your Vantage API token for authentication. This process avoids extra storage costs incurred by the OpenCost integration. The agent's architecture eliminates the need for deploying OpenCost-specific Prometheus pods, which makes scaling easier. 
 
 ## Service Compatibility
 
-The agent is compatible with the following services: 
-
-- Azure Kubernetes Service (AKS)
-
-- Google Kubernetes Engine (GKE)
+The Vantage Kubernetes agent is compatible with the following services: 
 
 - Amazon Elastic Kubernetes Service (EKS)
+- Azure Kubernetes Service (AKS)
+- Google Kubernetes Engine (GKE)
 
 :::note
 At this time, the agent does not support custom rates for on-premises servers. Note that this is a planned future feature. If you have an on-premises cluster and would like to track these costs, see the [OpenCost](/opencost) documentation.
 :::
 
-As long as the cost data for an underlying cluster instance is ingested into Vantage, it is possible to calculate the corresponding pod costs.
+As long as the cost data for an underlying cluster instance is ingested into Vantage via a cloud integration, it is possible to calculate the corresponding pod costs.
 
 ## Collected Metrics
 
@@ -41,13 +39,7 @@ The agent collects the following metrics:
 - Container
 - Kubernetes service
 - Kubernetes namespace
-- Namespace labels
-- Annotations (optionally enabled)
 
-In addition, the agent also reflects the following items in Cost Reports:
-
-- Reserved Instance and Savings Plan discounts
-- Spot prices
 
 ## Install Vantage Kubernetes Agent
 
@@ -65,24 +57,63 @@ The following prerequisites are required before you install the Vantage Kubernet
 
 ## Create a Connection
 
+:::info
+The following steps are also provided in the Vantage Kubernetes agent Helm chart repository. See [the repository](https://github.com/vantage-sh/helm-charts/tree/main/charts/vantage-kubernetes-agent) for all value configurations.
+:::
+
 To set up a _new_ Kubernetes agent connection:
 
-1. Add the repository for the Vantage agent Helm chart. 
+1. Add the repository for the Vantage Kubernetes agent Helm chart. 
    
    ```bash
    helm repo add vantage https://vantage-sh.github.io/helm-charts
    ```
 
-2. Install the `vantage-kubernetes-agent` chart. Ensure you update the values for `VANTAGE_API_TOKEN` and `CLUSTER_ID`.
+2. Install the `vantage-kubernetes-agent` Helm chart. Ensure you update the values for `VANTAGE_API_TOKEN` (obtained in the [Prerequisites](/kubernetes_agent#prerequisites) above) and `CLUSTER_ID` (the unique value for your cluster).
    
    ```bash
-   helm install -n vantage vantage-kubernetes-agent vantage/vantage-kubernetes-agent --set agent.token=$VANTAGE_API_TOKEN,agent.clusterID=$CLUSTER_ID
+   helm upgrade -n vantage vka vantage/vantage-kubernetes-agent --install --set agent.token=$VANTAGE_API_TOKEN,agent.clusterID=$CLUSTER_ID --create-namespace
    ```
 
-3. From the Vantage console, on the [Integrations page](https://console.vantage.sh/settings/integrations), click....then click....
+   The limits provided within the Helm chart are set low to support small clusters (approximately 10 nodes) and should be considered the minimum values for deploying an agent.
 
+   Estimates for later clusters are roughly:
+   - ~2 CPU/1000 node
+   - ~1 MB/node
+   - ~16 KB/container
+   
+   For example, a 100-node cluster with 3000 containers (10 pods per node, 3 containers per pod) would be approximately 150 MB and 200 mCPU. These amounts are estimates, which will vary based on node density, label usage, cluster activity, etc. The agent should reach an approximate steady state after about one hour of uptime and can be tuned accordingly after the fact.
 
-Costs are aggregated and exported several times throughout the day and updated within the Vantage platform nightly.
+   To set these options, extend the `--set` flag. You can also include the values using one of the [many options Helm supports](https://helm.sh/docs/chart_template_guide/values_files/):
+   ```
+   --set agent.token=$VANTAGE_API_TOKEN,agent.clusterID=$CLUSTER_ID,resources.limits.memory=100Mi,resources.requests.memory=100Mi
+   ```
+
+### Validate Installation
+
+Follow the steps below to validate the agent's installation. 
+
+1. Once installed, the agent's pod should become `READY`:
+   ```bash
+   ➜ kubectl -n vantage get po
+   NAME                             READY   STATUS    RESTARTS   AGE
+   vka-vantage-kubernetes-agent-0   1/1     Running   0          54m
+   ```
+2. Logs should be free of `ERROR` messages:
+   ```bash
+   ➜  containers kubectl -n vantage logs -f vka-vantage-kubernetes-agent-0
+   {"time":"2023-10-23T22:01:12.065481528Z","level":"INFO","msg":"found nodes","nodes":2}
+   ...
+   {"time":"2023-10-23T22:01:12.471399742Z","level":"INFO","msg":"finished initializing"}
+   ```
+3. Agent reporting should occur once per hour at the start of the hour and should not generate an `ERROR` log line. It should also attempt a report soon after the initial start:
+   ```bash
+   {"time":"2023-10-23T22:01:00.015243974Z","level":"INFO","msg":"reporting now"}
+   {"time":"2023-10-23T22:01:01.168390414Z","level":"INFO","msg":"finished reporting"}
+   {"time":"2023-10-23T22:01:01.169876296Z","level":"INFO","msg":"next report window","start":"2023-10-23T22:00:00Z","end":"2023-10-23T23:00:00Z","sleeping_seconds":3598.830199804}
+   ```
+
+Costs are exported from the cluster hourly and then made available nightly. It's important to note that these costs might encounter delays based on their associated cloud integration's cost data. For instance, if there is a one-day delay in an AWS Cost and Usage Report, the clusters dependent on that data will experience a similar delay.
 
 ## Migrate Costs from OpenCost to Vantage Kubernetes Agent
 
@@ -90,4 +121,4 @@ If you are moving from an OpenCost integration to the agent-based integration, y
 
 ### Maintaining OpenCost Filters
 
-If you previously used the OpenCost integration and are transitioning to the new agent-based integration, your existing filters will be retained. It's important to note that, in situations where labels contained characters excluded from Prometheus labels, such as `-`, the OpenCost integration received the normalized versions of those labels from Prometheus. The Vantage agent, on the other hand, directly retrieves labels from the `kube-apiserver`, resulting in more precise data. However, this change may necessitate updates to filters that previously relied on the normalized values. You can contact [support@vantage.sh](mailto:support@vantage.sh) to have these filters converted for you.
+If you previously used the OpenCost integration and are transitioning to the new agent-based integration, your existing filters will be retained. It's important to note that in situations where labels contained characters excluded from Prometheus labels, such as `-`, the OpenCost integration received the normalized versions of those labels from Prometheus. The Vantage Kubernetes agent, on the other hand, directly retrieves labels from the `kube-apiserver`, resulting in more precise data. However, this change may necessitate updates to filters that previously relied on the normalized values. You can contact [support@vantage.sh](mailto:support@vantage.sh) to have these filters converted for you.

--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -1,0 +1,93 @@
+---
+id: kubernetes_agent
+title: Kubernetes (Vantage Agent)
+description: This page walks through how to connect the Vantage Kubernetes agent with your Kubernetes cluster.
+---
+
+# Kubernetes (Vantage Agent)
+
+:::note Beta
+The Vantage Kubernetes agent is currently in Beta.
+:::
+
+The Vantage Kubernetes agent is the default, recommended configuration to ingest cost and usage data from Kubernetes clusters to Vantage. The agent is a Docker container that's run in your Kubernetes cluster. The agent collects metrics and uploads them to Vantage. 
+
+## Agent Functionality 
+
+The Vantage agent relies on native Kubernetes APIs, such as `kube-apiserver` for metadata and `kubelet` for container data. Access to these APIs is controlled via Kubernetes RBAC using a Service Account and ClusterRole, included in the Vantage [Kubernetes Agent Helm chart](https://github.com/vantage-sh/helm-charts). 
+
+Data is periodically collected and stored for aggregation, then sent directly to Vantage service through an API with your Vantage API token for authentication, which avoids extra storage costs. This architecture eliminates the need for deploying OpenCost-specific Prometheus pods, making scaling easier. 
+
+## Service Compatibility
+
+The agent is compatible with the following services: 
+
+- Azure Kubernetes Service (AKS)
+
+- Google Kubernetes Engine (GKE)
+
+- Amazon Elastic Kubernetes Service (EKS)
+
+:::note
+At this time, the agent does not support custom rates for on-premises servers. Note that this is a planned future feature. If you have an on-premises cluster and would like to track these costs, see the [OpenCost](/opencost) documentation.
+:::
+
+As long as the cost data for an underlying cluster instance is ingested into Vantage, it is possible to calculate the corresponding pod costs.
+
+## Collected Metrics
+
+The agent collects the following metrics:
+
+- Container
+- Kubernetes service
+- Kubernetes namespace
+- Namespace labels
+- Annotations (optionally enabled)
+
+In addition, the agent also reflects the following items in Cost Reports:
+
+- Reserved Instance and Savings Plan discounts
+- Spot prices
+
+## Install Vantage Kubernetes Agent
+
+### Prerequisites
+
+The following prerequisites are required before you install the Vantage Kubernetes agent:
+
+- The [Helm package manager](https://helm.sh/) for Kubernetes 
+
+- `kubectl`
+
+- A running Kubernetes cluster
+
+- A [Vantage API token](/vantage_account#get-a-vantage-api-token) with READ and WRITE scopes enabled
+
+## Create a Connection
+
+To set up a _new_ Kubernetes agent connection:
+
+1. Add the repository for the Vantage agent Helm chart. 
+   
+   ```bash
+   helm repo add vantage https://vantage-sh.github.io/helm-charts
+   ```
+
+2. Install the `vantage-kubernetes-agent` chart. Ensure you update the values for `VANTAGE_API_TOKEN` and `CLUSTER_ID`.
+   
+   ```bash
+   helm install -n vantage vantage-kubernetes-agent vantage/vantage-kubernetes-agent --set agent.token=$VANTAGE_API_TOKEN,agent.clusterID=$CLUSTER_ID
+   ```
+
+3. From the Vantage console, on the [Integrations page](https://console.vantage.sh/settings/integrations), click....then click....
+
+
+Costs are aggregated and exported several times throughout the day and updated within the Vantage platform nightly.
+
+## Migrate Costs from OpenCost to Vantage Kubernetes Agent
+
+If you are moving from an OpenCost integration to the agent-based integration, you can contact [support@vantage.sh](mailto:support@vantage.sh) to have your previous integration data maintained.
+
+### Maintaining OpenCost Filters
+
+If you previously used the OpenCost integration and are transitioning to the new agent-based integration, your existing filters will be retained. It's important to note that, in situations where labels contained characters excluded from Prometheus labels, such as `-`, the OpenCost integration received the normalized versions of those labels from Prometheus. The Vantage agent, on the other hand, directly retrieves labels from the `kube-apiserver`, resulting in more precise data. However, this change may necessitate updates to filters that previously relied on the normalized values. You can contact [support@vantage.sh](mailto:support@vantage.sh) to have these filters converted for you.

--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -32,15 +32,6 @@ At this time, the agent does not support custom rates for on-premises servers. N
 
 As long as the cost data for an underlying cluster instance is ingested into Vantage via a cloud integration, it is possible to calculate the corresponding pod costs.
 
-## Collected Metrics
-
-The agent collects the following metrics:
-
-- Container
-- Kubernetes service
-- Kubernetes namespace
-
-
 ## Install Vantage Kubernetes Agent
 
 ### Prerequisites
@@ -58,7 +49,7 @@ The following prerequisites are required before you install the Vantage Kubernet
 ## Create a Connection
 
 :::info
-The following steps are also provided in the Vantage Kubernetes agent Helm chart repository. See [the repository](https://github.com/vantage-sh/helm-charts/tree/main/charts/vantage-kubernetes-agent) for all value configurations.
+The following steps are also provided in the Vantage Kubernetes agent Helm chart repository. See [the Helm chart repository](https://github.com/vantage-sh/helm-charts/tree/main/charts/vantage-kubernetes-agent) for all value configurations.
 :::
 
 To set up a _new_ Kubernetes agent connection:

--- a/sidebars.js
+++ b/sidebars.js
@@ -49,6 +49,7 @@ module.exports = {
           label: "Kubernetes",
           items: [
             "connecting_kubernetes",
+            "kubernetes_agent",
             "opencost",
             "kubernetes_container_insights",
           ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -52,6 +52,7 @@ module.exports = {
             "kubernetes_agent",
             "opencost",
             "kubernetes_container_insights",
+            "kubernetes",
           ],
         },
         "connecting_datadog",
@@ -92,7 +93,6 @@ module.exports = {
         },
         "cost_recommendations",
         "data_dictionary",
-        "kubernetes",
         {
           type: "category",
           label: "Notifications",


### PR DESCRIPTION
@brookemckim @macb 

Here are the initial updates for the Kubernetes agent docs. I have the following questions:

- What is the official product name — the "Vantage Kubernetes agent?"
- Please confirm the installation prereqs. I've noted
- In the _Create a Connection_ section, for the first step, do they need to be in a specific directory — like "From your cluster, add the repository for the Vantage agent Helm chart."
- In _Create a Connection_ section, step 2, should I provide additional detail on how to get the cluster ID? Is that something that's obvious?
- I will need other instructions on what they do next in the Vantage console. 
- I will need instructions on migration. What do they need to do, or is it to just reach out to Support?
- How do you enable annotation collection?

In addition, I will need to work on updating a number of other pages for GA, mostly to add a note that this is the default method:

-  https://docs.vantage.sh/connecting_kubernetes
-  https://docs.vantage.sh/opencost
-  https://docs.vantage.sh/kubernetes_container_insights
-  https://docs.vantage.sh/kubernetes