### PR TITLE
Additional edits for K8s pages

### DIFF
--- a/docs/connecting_azure.md
+++ b/docs/connecting_azure.md
@@ -59,7 +59,7 @@ Vantage currently supports cost recommendations for Compute Reserved Instances a
 
 ## Kubernetes and AKS
 
-Vantage supports Kubernetes cost allocation on Azure, including Kubernetes clusters running on VMs or through AKS. Vantage makes use of [OpenCost](/opencost), an open-source CNCF project, to monitor and ingest Kubernetes costs from Azure.
+Vantage supports Kubernetes cost allocation on Azure, including Kubernetes clusters running on VMs or through AKS. Vantage recommends using the [Vantage Kubernetes Agent](/kubernetes_agent) to monitor and ingest Kubernetes costs from Azure.
 
 ## Feature Availability for Azure
 

--- a/docs/connecting_kubernetes.md
+++ b/docs/connecting_kubernetes.md
@@ -1,20 +1,29 @@
+---
+id: connecting_kubernetes
+title: Setup Kubernetes
+description: This page walks through the options for how to integrate Vantage with your Kubernetes clusters.
+keywords:
+    - Kubernetes
+    - Connect Kubernetes
+---
+
 # Setup Kubernetes
 
-Vantage allows you to see in-cluster costs for Kubernetes clusters including seeing costs by container, service, namespace and label. Vantage supports any type of Kubernetes deployment (EKS, GKE, self-managed, etc.). This allows teams to easily understand how their shared clusters are being utilized and how to account for cluster costs across teams and applications. 
+Vantage allows you to see in-cluster costs for Kubernetes clusters, including seeing costs by Container, Service, Namespace and Label. Vantage supports any type of Kubernetes deployment (e.g., EKS, GKE, self-managed). This allows teams to easily understand how their shared clusters are being utilized and how to account for cluster costs across teams and applications. 
 
-Vantage recommends integrating with [OpenCost](/opencost) as the preferred method for ingesting and tracking Kubernetes costs.
+The [Vantage Kubernetes Agent](/kubernetes_agent) is the recommended integration point for ingesting Kubernetes costs into Vantage.
 
-## How it Works
+## How the Integration Works
 
-Vantage looks at Pod lifecycle data and the underlying nodes that pods run on. By joining the lifecycle data of each Pod (along with the greater of either the reserved or actual CPU/memory prescribed) with the specific rate information of the underlying node, Vantage allocates subcategories of the node (vCPU, Memory, GPU, Storage, etc) to the Pod. The lifecycle of the EC2 instance is also automatically determined (on-demand, spot, reserved, savings plan, EDP, etc). This allows you to see costs by the following dimensions:
+Vantage looks at Pod lifecycle data and the underlying nodes that pods run on. By joining the lifecycle data of each pod (along with the greater of either the reserved or actual CPU/memory prescribed) with the specific rate information of the underlying node, Vantage allocates subcategories of the node (vCPU, Memory, GPU, Storage, etc.) to the pod. The lifecycle of the EC2 instance is also automatically determined (On-Demand, Spot, Reserved, Savings Plans, EDP, etc.). This allows you to see costs by the following dimensions:
 
-- By container
-- By Kubernetes service
-- By Kubernetes namespace
-- By Kubernetes label
+- By Container
+- By Kubernetes Service
+- By Kubernetes Namespace
+- By Kubernetes Label
 
-Vantage automatically profiles your clusters for all existing services, namespaces and labels to make available for you in the Vantage console as dimensions for filtering and reporting. 
+Vantage automatically profiles your clusters for all existing Services, Namespaces, and Labels to be available for you in the Vantage console as dimensions for filtering and reporting. 
 
-## Enabling Kubernetes Costs
+## Enable Kubernetes Costs
 
-Vantage supports seeing Kubernetes costs via OpenCost and Prometheus. You can get started by following these [instructions](https://docs.vantage.sh/opencost/).
+To get started, follow the instructions for setting up the [Vantage Kubernetes Agent](/kubernetes_agent).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -53,7 +53,7 @@ Next, create a data integration between at least one of your providers and Vanta
       icon: '/img/logos/logo-icon-kubernetes.svg',
       iconAltText: 'Kubernetes logo',
       title: 'Kubernetes',
-      content: 'Vantage recommends OpenCost as the preferred integration point for Kubernetes costs, but it can also ingest metrics through AWS Container Insights.',
+      content: 'Vantage allows you to see in-cluster costs for Kubernetes clusters, including seeing costs by container, service, namespace and label. The Vantage Kubernetes Agent is the recommended integration point for ingesting Kubernetes costs into Vantage.',
       link: "/connecting_kubernetes",
     },
     {

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,12 +1,20 @@
 ---
+id: kubernetes
+title: Kubernetes Costs
 description: Kubernetes cost reporting and efficiency metrics documentation for Vantage including costs by cluster, namespace, and label as well as idle costs and pod efficiency metrics.
+keywords:
+    - Kubernetes 
+    - Kubernetes costs
+    - Kubernetes efficiency metrics
 ---
 
-# Kubernetes Costs
+# Kubernetes Costs and Efficiency Metrics
 
-Vantage has two sets of tools for viewing and optimizing Kubernetes costs. The first is Kubernetes costs reporting in [Cost Reports](/cost_reports). The second is Kubernetes efficiency metrics in the devoted [Kubernetes](https://console.vantage.sh/kubernetes) page in the console. Kubernetes Cost Reports are most useful to drill into costs by cluster, namespace, service, and label as well as combine Kubernetes costs with other providers such as a database or cache layer. Kubernetes Efficiency Metrics display the cost efficiency down to the pod level of a cluster and are useful for rightsizing and cost optimization.
+Vantage has two sets of tools for viewing and optimizing Kubernetes costs: viewing Kubernetes costs in [Cost Reports](/cost_reports) and viewing Kubernetes efficiency metrics in the devoted [Kubernetes page](https://console.vantage.sh/kubernetes) in the console. 
+- **Kubernetes Cost Reports** are most useful to drill into costs by Cluster, Namespace, Service, and Label as well as combine Kubernetes costs with other providers, such as a database or cache layer. 
+- **Kubernetes Efficiency Metrics** display the cost efficiency down to the pod level of a cluster and are useful for rightsizing and cost optimization.
 
-## Kubernetes Cost Reporting
+## Kubernetes Cost Reports
 
 <div style={{display:"flex", justifyContent:"center"}}>
     <img alt="Resource Reports" width="80%" src="/img/vantage-kubernetes-reporting.png" />
@@ -14,9 +22,9 @@ Vantage has two sets of tools for viewing and optimizing Kubernetes costs. The f
 
 Kubernetes Cost Reports have cost visibility by Cluster, Label, Namespace, and Service. They include Kubernetes-specific filters and filter logic. This allows you to combine specific Kubernetes costs with other services. For example, a customer can see the costs of a specific service with corresponding RDS database costs.
 
-Cost reports also include forecasts which define Kubernetes specific filters will receive end-of-month forecasts. These forecasts are updated daily and give you confidence intervals of where your costs are likely to end up for the month.
+Cost Reports also include forecasts, which define Kubernetes-specific filters that will receive end-of-month forecasts. These forecasts are updated daily and give you confidence intervals of where your costs are likely to end up for the month.
 
-The costs displayed on these reports come from [OpenCost](/opencost). OpenCost calculates the cost of a running pod by looking at the CPU, RAM, GPU and storage usage and calculates the cost of each based on the cost of the underlying infrastructure. There is a formula for dividing the cost of a compute instance into CPU, RAM and GPU which then computes the cost per hour of each type of resource. OpenCost does all of the cost allocation calculations locally to your cluster and makes this data available for querying.
+If you use an OpenCost integration, the costs displayed on these reports come from [OpenCost](/opencost). OpenCost calculates the cost of a running pod by looking at the CPU, RAM, GPU and storage usage and calculates the cost of each based on the cost of the underlying infrastructure. There is a formula for dividing the cost of a compute instance into CPU, RAM and GPU which then computes the cost per hour of each type of resource. OpenCost does all the cost allocation calculations locally to your cluster and makes this data available for querying.
 
 Kubernetes costs are not included in monthly tracked infrastructure costs as they’re already captured from underlying EKS, GKE, or AKS costs.
 
@@ -26,21 +34,21 @@ Kubernetes costs are not included in monthly tracked infrastructure costs as the
     <img alt="Resource Reports" width="80%" src="/img/k8s-efficiency.png" />
 </div>
 
-There is a [Kubernetes](https://console.vantage.sh/kubernetes) portion of the Vantage console devoted to viewing Kubernetes costs and efficiency metrics. You can view connected clusters, namespaces and labels with the following information:
+Navigate to the [Kubernetes portion](https://console.vantage.sh/kubernetes) of the Vantage console to view Kubernetes costs and efficiency metrics. On the left navigation menu, select an option to view connected Clusters, Namespaces, and Labels. Each view contains a graph as well as a table with the following headings:
 
-- Name: The name of the cluster, namespace of label you’re viewing.
-- Idle Cost: A dollar value representation of the amount of resources requested that are idle.
-- Total Cost: A dollar value representation of the total cost of resources.
-- Cost Efficiency %: The ratio of idle costs and total costs.
+- **Name**. The name of the Cluster, Namespace, or Label you’re viewing.
+- **Idle Costs**. A dollar value representation of the amount of resources requested that are idle.
+- **Total Costs**. A dollar value representation of the total cost of resources.
+- **Cost Efficiency**. The percent ratio of idle costs and total costs.
 
-When viewing efficiency metrics for a cluster you can filter them in a couple different ways:
+You can filter efficiency metrics for a cluster using a few different options:
 
-- Change the date range to see how they have changed over time
-- Change the aggregation to see the metrics by cluster, namespace, label.
+- Change the date range to see how they have changed over time. Select the date options on the top right of the chart. 
+- Change the aggregation to see the metrics by Cluster, Namespace, or Label. From the resource list below each chart, click the icons next to each resource to view different aggregations. 
 
 ### Efficiency Calculations
 
-Pod resource efficiency is defined as the resource utilization versus the resource request over a given time window. These resource utilization metrics include CPU and RAM. When viewing efficiency it will be shown as a percentage. 100% means the resource allocation is fully efficient.
+Pod resource efficiency is defined as the resource utilization versus the resource request over a given time window. These resource utilization metrics include CPU and RAM. When viewing efficiency, it will be shown as a percentage. 100% means the resource allocation is fully efficient.
 
 Idle costs are defined as the difference between the cost of requested resources (CPU and Memory) and the associated usage of those costs:
 
@@ -49,18 +57,22 @@ idle_cost = (cpu_request_cost - cpu_usage_cost) +
             (memory_request_cost - memory_usage_cost)
 ```
 
-Efficiency metrics are available immediately after your OpenCost metrics are imported, generally once per day. For more information on how container costs are allocated, please consult the [OpenCost specification](https://github.com/opencost/opencost/blob/develop/spec/opencost-specv01.md).
+Efficiency metrics are available immediately after your OpenCost metrics are imported, generally once per day. For more information on how container costs are allocated for OpenCost integrations, please consult the [OpenCost specification](https://github.com/opencost/opencost/blob/develop/spec/opencost-specv01.md).
 
 ## Integration Methods
 
-Vantage recommends installing [OpenCost](/opencost) in your cluster in order to utilize our most granular reporting features and the cost efficiency metrics. While we work to upstream the efficiency metrics into the main OpenCost project, you can deploy the Vantage-maintained OpenCost branch at [quay.io/vantage-sh/opencost:efficiency](https://quay.io/vantage-sh/opencost:efficiency).
+:::tip
+Vantage recommends integrating with the [Vantage Kubernetes Agent](/kubernetes_agent) to utilize the most granular reporting features and the cost-efficiency metrics. 
+:::
 
-Efficiency metrics will be available up to 24 hours after updating your clusters. You can query the Amazon Managed Prometheus associated with your integration for `count(container_cpu_idle) by (cluster_id)` to verify the metrics are making it from your Kubernetes cluster to the Prometheus that Vantage will use to gather them periodically.
+For the Vantage Kubernetes Agent, costs are exported from the cluster hourly and then made available nightly. It's important to note that these costs might encounter delays based on their associated cloud integration's cost data. For instance, if there is a one-day delay in an AWS Cost and Usage Report, the clusters dependent on that data will experience a similar delay.
 
-In most cases Prometheus running on a Kubernetes cluster will not be exposed with a public endpoint. To get around this a second centralized Prometheus instance is deployed into your account to be used as an aggregation point which Vantage has both network and IAM access to query. Vantage can integrate with any publicly accessible Prometheus endpoint - including Grafana cloud.
+For OpenCost integrations, while we work to upstream the efficiency metrics into the main OpenCost project, you can deploy the Vantage-maintained OpenCost branch at [quay.io/vantage-sh/opencost:efficiency](https://quay.io/vantage-sh/opencost:efficiency).
 
-For Google Cloud, Azure, and on-prem support for Kubernetes efficiency metrics, please contact us at [support@vantage.sh](mailto:support@vantage.sh).
+Efficiency metrics will be available up to 24 hours after updating your clusters. For OpenCost users, you can query the Amazon Managed Prometheus associated with your integration for `count(container_cpu_idle) by (cluster_id)` to verify the metrics are making it from your Kubernetes cluster to the Prometheus that Vantage will use to gather them periodically.
 
-### Why we Recommend OpenCost vs Container Insights
+In most cases, Prometheus running on a Kubernetes cluster will not be exposed with a public endpoint. To get around this a second centralized Prometheus instance is deployed into your account to be used as an aggregation point which Vantage has both network and IAM access to query. Vantage can integrate with any publicly accessible Prometheus endpoint—including Grafana cloud.
 
-Container Insights stores all pod level system metrics such as CPU and RAM. From there Vantage queries CloudWatch for these metrics and does the cost allocation calculation. Container Insights is more expensive for users to run as they have to pay to store the system metrics and pay for the cost of Vantage querying these costs.
+:::info
+For Google Cloud, Azure, and on-premises support for Kubernetes efficiency metrics, please contact us at [support@vantage.sh](mailto:support@vantage.sh).
+:::

--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -105,6 +105,10 @@ Follow the steps below to validate the agent's installation.
 
 Costs are exported from the cluster hourly and then made available nightly. It's important to note that these costs might encounter delays based on their associated cloud integration's cost data. For instance, if there is a one-day delay in an AWS Cost and Usage Report, the clusters dependent on that data will experience a similar delay.
 
+:::tip
+You can view and manage your Kubernetes integration on [Kubernetes Integration page](https://console.vantage.sh/settings/kubernetes) in the console. Hover over the integration in the list, and click **Manage**.
+:::
+
 ## Migrate Costs from OpenCost to Vantage Kubernetes Agent
 
 If you are moving from an OpenCost integration to the agent-based integration, you can contact [support@vantage.sh](mailto:support@vantage.sh) to have your previous integration data maintained.

--- a/docs/kubernetes_container_insights.md
+++ b/docs/kubernetes_container_insights.md
@@ -1,9 +1,25 @@
+---
+id: kubernetes_container_insights
+title: Kubernetes (Container Insights)
+description: This page walks through how to integrate your Kubernetes costs via Container Insights in Vantage.
+keywords:
+  - Kubernetes
+  - Container Insights
+---
+
 # Kubernetes (Container Insights)
 
-Vantage follows the official [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-common-scenarios.html#CloudWatch-Agent-send-to-different-AWS-account) on securely sending CloudWatch logs to another AWS account to ingest Kubernetes costs through Container Insights. The steps below are for users who choose to use Container Insights, instead of the recommended [OpenCost](/opencost) integration.
+Vantage follows the official [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-common-scenarios.html#CloudWatch-Agent-send-to-different-AWS-account) on securely sending CloudWatch logs to another AWS account to ingest Kubernetes costs through Container Insights.
 
-## Deploy Cloudwatch Agent with Cross Account ARN
-The Cloudwatch agent [must be setup](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html) to collect metrics from your clusters. You will have to make one change on step 3 of the [AWS Container Insights setup instructions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html) and modify the `cwagent-configmap.yml`  to include the `role_arn`. Vantage will have provisioned this role for you already, see [below](#provision-a-cross-account-role).
+:::note
+The steps below are for users who choose to use Container Insights instead of the recommended [Vantage Kubernetes Agent](/kubernetes_agent) integration.
+:::
+
+## Deploy CloudWatch Agent with Cross-Account ARN
+
+The CloudWatch agent must be set up to collect metrics from your clusters. 
+
+Refer to the [AWS Container Insights setup instructions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-metrics.html). You will have to make one change on step 3 of these instructions and modify the `cwagent-configmap.yml` to include the `role_arn`. Vantage will have provisioned this role for you already. See the steps below, in the [Provision a Cross-Account Role](#provision-a-cross-account-role) section.
 
 ```yaml
 # create configmap for cwagent config
@@ -35,12 +51,12 @@ metadata:
 
 ## Adding Permissions for Node Roles
 
-After this is done you will have to modify the IAM permissions of the Node Role that is used for your EKS Cluster roles. They will require two changes:
+Next, you will have to modify the IAM permissions of the Node Role that is used for your EKS Cluster roles. They step will require two changes:
 
-1. An inline policy that allows the role to assumeRole the IAM Role on the Vantage side.
-2. Attachment of an AWS managed policy called `CloudWatchAgentServerPolicy` which allows the Node to send cloudwatch metrics.
+- An inline policy that allows the role to `assumeRole` the IAM role on the Vantage side.
+- Attachment of an AWS Managed Policy called `CloudWatchAgentServerPolicy`, which allows the node to send CloudWatch metrics.
 
-Each Node will have to assume the role above to write logs to your Vantage account. That means that each [node IAM role](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html) in your AWS account will need to attach the inline policy below. 
+Each node will have to assume the role above to write logs to your Vantage account. That means that each [node IAM role](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html) in your AWS account will need to attach the inline policy below.
 
 ```json
 {
@@ -55,11 +71,13 @@ Each Node will have to assume the role above to write logs to your Vantage accou
 }
 ```
 
-**Note:** If using self-managed nodes on EKS you will have to find out the node roles you have assigned within the cluster yourself.
+:::note
+If you use self-managed nodes on EKS, you will have to find out the node roles you have assigned within the cluster yourself.
+:::
 
 Now, attach the `CloudWatchAgentServerPolicy` policy to each node role.
 
-## Provision a Cross Account Role
+## Provision a Cross-Account Role {#provision-a-cross-account-role}
 
 Vantage will provision an IAM role internally with the following trust policy and attach the `CloudWatchAgentServerPolicy` managed policy.
 

--- a/docs/opencost.md
+++ b/docs/opencost.md
@@ -1,30 +1,42 @@
+---
+id: opencost
+title: Kubernetes (OpenCost)
+description: This page walks through how to integrate your Kubernetes costs via OpenCost in Vantage.
+keywords:
+    - Kubernetes
+    - OpenCost
+---
+
 # Kubernetes (OpenCost)
 
-[OpenCost](https://www.opencost.io) is an emerging [specification](https://github.com/opencost/opencost/blob/develop/spec/opencost-specv01.md) for Kubernetes costs. Once OpenCost is deployed on your Kubernetes cluster, Vantage can ingest costs by leveraging Prometheus remote write functionality to retrieve and ingest cluster costs accordingly to make available in the Vantage console accordingly. All Kubernetes environments are supported by OpenCost, including AWS, GCP, Azure, and on-prem, are supported by Vantage.
+[OpenCost](https://www.opencost.io) is an emerging [specification](https://github.com/opencost/opencost/blob/develop/spec/opencost-specv01.md) for Kubernetes costs. Once OpenCost is deployed on your Kubernetes cluster, Vantage can ingest costs by leveraging the Prometheus remote write functionality to retrieve and ingest cluster costs accordingly to make available in the Vantage console. All Kubernetes environments are supported by OpenCost, including AWS, GCP, Azure, and on-premises, are supported by Vantage.
 
-OpenCost is the recommended way to integrate Kubernetes cost reporting into Vantage because of simplicity, ease of use as well as the most cost effective manner relative to other native tools offered by infrastructure providers such as container insights.
-
-# Overview
-
-:::info
-To setup OpenCost in Azure or Google Cloud please contact us to be included in private support for Azure Monitor Managed Service for Prometheus or Google Cloud Managed Service for Prometheus.
+:::note
+The steps below are for integrations that use OpenCost instead of the recommended [Vantage Kubernetes Agent](/kubernetes_agent) integration.
 :::
 
-Vantage makes it easy to deploy and integrate with OpenCost. Here are the steps for how this is done:
+## Deploy and Integrate with OpenCost
 
-1. An AWS Managed Prometheus Workspace will be provisioned into your AWS Account in us-east-1 - which the Vantage cross account IAM Role will query directly to ingest OpenCost data.
-2. An IAM User is created with permissions to write to this newly created workspace.
-3. OpenCost and Prometheus are deployed to your Kubernetes cluster and configured to remote_write to the AWS Managed Prometheus. The created IAM User credentials are used for authentication.
-4. Vantage will regularly query the AWS Managed Prometheus Workspace to keep your Kubernetes cost information up-to-date.
+:::info
+To set up OpenCost in Azure or Google Cloud, please contact us at [support@vantage.sh](mailto:support@vantage.sh) to be included in private support for Azure Monitor Managed Service for Prometheus or Google Cloud Managed Service for Prometheus.
+:::
 
-To get started with this integration visit the [integrations](https://console.vantage.sh/settings/integrations) page and select the AWS account you would like to get started with. Deploying a Managed Prometheus per account is optional. You can use the single Managed Prometheus Workspace across all regions across all accounts.
+Vantage makes it easy to deploy and integrate with OpenCost. Here are the steps for how the integration is done:
 
-If you already have a hosted Prometheus solution (such as Grafana) you can contact support@vantage.sh to integrate directly.
+1. An AWS Managed Prometheus Workspace will be provisioned into your AWS account in _us-east-1_—which the Vantage Cross-Account IAM role will query directly to ingest OpenCost data.
+2. An IAM user is created with permissions to write to this newly created workspace.
+3. OpenCost and Prometheus are deployed to your Kubernetes cluster and configured to `remote_write` to the AWS Managed Prometheus. The created IAM user credentials are used for authentication.
+4. Vantage will regularly query the AWS Managed Prometheus Workspace to keep your Kubernetes cost information up to date.
 
-## Check that OpenCost data is being ingested
+To get started with this integration, navigate to the [Integrations](https://console.vantage.sh/settings/integrations) page in the Vantage console, and select the AWS account you would like to get started with. 
 
-Once the integration is deployed you can check the Kubernetes [integration page](https://console.vantage.sh/settings/integrations) in the Vantage console to see if data is flowing. If you see the cluster names listed on this page then data is being ingested and your Kubernetes cost data through OpenCost will be available within a day or two.
+Deploying a Managed Prometheus per account is optional. You can use the single Managed Prometheus Workspace across all regions, across all accounts. If you already have a hosted Prometheus solution (such as Grafana), you can contact [support@vantage.sh](mailto:support@vantage.sh) to integrate directly.
 
-<div style={{display:"flex", justifyContent:"center"}}>
-    <img alt="OpenCost is working" width="60%" src="/img/opencost_working.png" />
+## Validate OpenCost Data Is Being Ingested
+
+1. Once the integration is deployed, you can check the [Kubernetes Integration page](https://console.vantage.sh/settings/integrations) in the Vantage console to see if data is flowing. 
+2. If you see the cluster names listed below, then data is being ingested and your Kubernetes cost data through OpenCost will be available within a day or two.
+
+<div style={{ display: "flex", justifyContent: "center", borderRadius: 10, boxShadow: "0 2px 4px rgba(0, 0, 0, 0.1)" }}>
+    <img alt="OpenCost is working" width="60%" src="/img/opencost_working.png" style={{ borderRadius: 10 }} />
 </div>


### PR DESCRIPTION
Hi @macb — Here are the remaining updates for Kubernetes-related docs. Please let me know if you would like me to make any other changes. 

**I will wait to merge this until GA and will make one final commit to remove the Early Access note on the agent page at that time.**

Here is a breakdown of the changes by page.
 
`connecting_azure`:
- Changed a note about OpenCost to say the Kubernetes agent is the recommended way

`connecting_kubernetes`:
- Changed note about recommended integration point to the Agent at the top and bottom
- All other changes are just copy edits

`getting_started`:
- Changed language to refer to the agent as the preferred method

`kubernetes` (Kubernetes Costs and Efficiency Metrics page):
- Got rid of the small section on "Why we Recommend OpenCost vs Container Insights"
- Added some langauge about the agent being the preferred method.
- Left in OpenCost stuff, but added "If you have an OpenCost integration…" before areas that mentioned that
- Copy edits

`kubernetes_agent`:
- Added a tip to where they can manage their integration in the console
`container_insights`:
- Changed note at top to say the agent is the recommended integration
- Copy edits

`opencost`:
- Removed language about it being the recommended integration option
- Copy edits

That should be all the pages that mention Kubernetes on here! :-D 