### PR TITLE
Unlist integration page

### DIFF
--- a/docs/connecting_open_ai.md
+++ b/docs/connecting_open_ai.md
@@ -1,4 +1,14 @@
+---
+id: connecting_open_ai
+title: OpenAI
+unlisted: true
+---
+
 # OpenAI
+
+:::caution Important
+New OpenAI integrations are currently unavailable due to API issues. 
+:::
 
 Vantage has the ability to visualize, filter on and forecast your OpenAI costs. All you'll need to do is generate an OpenAI API Key and Vantage will ingest your cost and usage data from OpenAI accordingly. Before getting started, [ensure you have a free Vantage account](https://console.vantage.sh/signup) then follow the steps below to integrate OpenAI costs.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -99,13 +99,6 @@ Next, create a data integration between at least one of your providers and Vanta
       link: "/connecting_fastly",
     },
     {
-      icon: '/img/logos/logo-icon-openai.svg',
-      iconAltText: 'OpenAI logo',
-      title: 'OpenAI',
-      content: 'Vantage integrates with your OpenAI account through an API token. OpenAI API tokens are free for you to create—and adding them to the Vantage console only takes a few minutes.',
-      link: "/connecting_open_ai",
-    },
-    {
       icon: '/img/logos/logo-icon-oracle.svg',
       iconAltText: 'Oracle Cloud logo',
       title: 'Oracle Cloud',

--- a/sidebars.js
+++ b/sidebars.js
@@ -104,7 +104,6 @@ module.exports = {
         },
         "connecting_databricks",
         "connecting_fastly",
-        "connecting_open_ai",
         "connecting_oracle",
         "connecting_confluent",
       ],


### PR DESCRIPTION
Mark OpenAI as unlisted, since new OpenAI integrations are currently unavailable due to API issues. 