### PR TITLE
Add anchor links

### DIFF
--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -91,7 +91,7 @@ AWS imposes a minimum 30-day hold time for all Reserved Instances before you can
 
 Autopilot purchases RIs in denormalized units that are applicable to any size of instance in the same family, which you can see if you reference the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/apply_ri.html). In other words, if you change sizes within the same instance family, the reservations still apply!
 
-## Autopilot Controls
+## Autopilot Controls {#autopilot-controls}
 
 ![Autopilot Controls](/img/autopilot_controls.png)
 
@@ -118,7 +118,7 @@ Autopilot Controls can be changed as often as you’d like. That being said, we 
 
 Once a setting is changed, the changes take effect between 24 and 48 hours. Autopilot purposefully will impose a minimum 24 hour delay before making any changes from Autopilot controls. Please note that because of a 30 day minimum holding period made by AWS with reserved instances, there may be certain cases where even adjusting controls could take some time to be applied.
 
-### Autopilot Controls Graphs
+### Autopilot Controls Graphs {#autopilot-controls-graphs}
 
 The Y-axis for Autopilot controls graphs can represent different things depending on the service you're looking at. There are two classes of units represented on the Y-axis that are listed below with their corresponding explanations:
 

--- a/docs/budgets.md
+++ b/docs/budgets.md
@@ -41,7 +41,7 @@ If the Cost Report you’re saving has budget alerts attached to it, we will ask
 
 If you have existing budgets in spreadsheets or another tool you can import them all at once by uploading a CSV file. Click the upload icon next to "New Budget" to get started.
 
-### Expected Format
+### Expected Format {#expected-format}
 
 An imported budget should be a CSV that contains a header row in which the first value is a unique string or identifier and all subsequent values are a month in the format of “YYYY-MM” (e.g. 2023-02 for February 2023). Every subsequent row in the CSV is the name of the budget and values expressed as decimals for every month there is a budget present for. An example format is shown below.
 

--- a/docs/connecting_aws.md
+++ b/docs/connecting_aws.md
@@ -6,13 +6,13 @@ Vantage understands security concerns and aims to provide as secure of a connect
 
 This means that Vantage **never** needs access credentials, account logins, or passwords for AWS.
 
-### Read-Only by Default
+### Read-Only by Default {#read-only-by-default}
 
 When you create a Cross-Account IAM Role using the provided CloudFormation template or by running the Terraform below, you provide Vantage with various [permissions](https://docs.vantage.sh/permissions_aws/). All these permissions, by default, are read-only. We created this list of permissions based on the official [AWS ReadOnlyAccess policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html). In addition, we removed some of the permissions AWS includes in this list to prevent Vantage from seeing information like reading from S3 buckets and reading from databases.
 
 Vantage only collects metadata about your infrastructure and never attempts to read sensitive information from the underlying services. Our CloudFormation template is public, and you can [audit the template's list of permissions here](https://vantage-public.s3.amazonaws.com/vantage-integration-latest.json).
 
-## Connecting Multiple AWS Accounts
+## Connecting Multiple AWS Accounts {#connecting-multiple-aws-accounts}
 
 Vantage allows you to connect multiple AWS accounts; however, we strongly advise that you connect your **root or management** AWS account first. When you connect the root account, you can see all costs for the organization, including linked accounts.
 
@@ -47,7 +47,7 @@ During onboarding, instead of following the CloudFormation process, you can use 
 
 If you want to create IAM roles manually or use another tool to manage your infrastructure, you can create the necessary cross-account role. During onboarding, instead of following the CloudFormation process, select the **IAM Role** option. You will be presented with a Trust Relationship and an Inline Policy that is required for the role. After creating the role, return to the onboarding page and submit the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) of the created role to complete the connection.
 
-## AWS Data Ingestion Delay
+## AWS Data Ingestion Delay {#aws-data-ingestion-delay}
 
 Vantage creates both an IAM role as well as a [Cost and Usage Report (CUR)](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html) integration through the same provided CloudFormation template and Terraform file. While an IAM role is created within a minute, and historical data can be populated almost immediately, it can take AWS up to 24 hours to deliver the first CUR to Vantage. As a result, only partial data will be present until this first CUR is received.
 

--- a/docs/connecting_azure.md
+++ b/docs/connecting_azure.md
@@ -35,7 +35,7 @@ This will output the following:
 
 Record the appId, tenant and password as you will enter these into the Vantage console.
 
-### Grant the Service Principal Permissions
+### Grant the Service Principal Permissions {#granting-the-service-principal-permissions}
 
 Grant Permissions to the 'appId' from the service principal created above. The scope can be a subscription or management group.
 

--- a/docs/cost_reports.md
+++ b/docs/cost_reports.md
@@ -38,7 +38,7 @@ Head to the [Saved Filters](https://console.vantage.sh/saved_filters) page in Co
 
 When combining multiple Saved Filters on Cost Reports, "AND" logic will be used. This is in contrast to combining multiple normal filters where "OR" logic is used.
 
-## Saving Cost Reports
+## Saving Cost Reports {#saving-cost-reports}
 
 When you have selected which filters to apply to the report you can save your changes and name the report. Select "Save As New" to create a new Cost Report with your changes or "Save Changes" to modify the current report. When you change the date range, date bucket (such as "Last 30 Days"), or Grouping you may also save those changes permanently. The new date range, date bucket, and grouping will persist to the [Overview](/overview) page. When saving a report which only includes changes to Filter Sets, the Overview page will show costs for the last 6 months.
 
@@ -70,7 +70,7 @@ Additionally, you can click in to see the category and subcategory costs on a pe
     <img alt="Example of a Single Resource Costs" width="80%" src="/img/per_resource_individual.png" />
 </div>
 
-## Percent Based Cost Allocation
+## Percent Based Cost Allocation {#percent-based-cost-allocation}
 
 It can be useful to show back shared resources like support costs or multi-tenant databases to the team or department utilizing them. As filters are set in a cost report, Vantage will query for costs that meet all of those conditions. In the event that a percentage is set by the customer on a Filter Set, that percentage will be applied to all of the matching costs and represented accordingly in the Cost Report.
 
@@ -133,7 +133,7 @@ To sort the table by multiple columns, Shift + Click on the column headers. You 
 
 **Limitations.** Costs by category and resource and forecasts are not currently supported when grouping by multiple dimensions. As costs can be duplicated across multiple tag keys, grouping by multiple tag keys is not supported.
 
-## Folders
+## Folders {#cost-report-folders}
 
 <div style={{display:"flex", justifyContent:"center"}}>
     <img alt="Cost Report Folders" width="80%" src="/img/folders-nobg.png" />
@@ -147,7 +147,7 @@ Cost Report folders give you an easy way to organize Cost Reports. You can quick
 
 Cost Report folders include several additional features for sharing and quickly viewing costs. By pressing the new "View in Overview" button in the top right of any folder, you can see all of its reports summarized on the Overview page. From that page you can also share a link with teammates. For example, you can organize all the costs associated with one team or business unit in one folder then share the link with that team so they can view all their costs in one place.
 
-## Exporting Cost Reports
+## Exporting Cost Reports {#exporting-cost-reports}
 
 <div style={{display:"flex", justifyContent:"center"}}>
     <img alt="Cost Report Exports" width="40%" src="/img/cost-report-exports.png" />
@@ -180,7 +180,7 @@ When the Export is finished generating, you’ll receive an email with a link to
 
 To compare costs day by day, week by week, or month by month on Cost Reports you can toggle the "By Date" selector above the cost table. This will show a view of costs at the same date binning as selected for the graphical display of costs on the Cost Report. To switch back to the previous, current, and percent change view, select "Cumulative".
 
-## Dashboards
+## Dashboards {#dashboards}
 
 <div style={{display:"flex", justifyContent:"center"}}>
     <img alt="Dashboards" width="80%" src="/img/dashboards.png" />

--- a/docs/hidden_costs.md
+++ b/docs/hidden_costs.md
@@ -11,7 +11,7 @@ keywords:
 
 With team accountability and executive reporting in place, there are usually opportunities to turn off or optimize resources that are unexpectedly driving costs. Vantage has numerous "cost debugging" features to help you drill down into where your spend is going.
 
-## Review Active Resources
+## Review Active Resources {#active-resources}
 
 <div style={{display:"flex", justifyContent:"center"}}>
     <img alt="Snowflake Cost Reports" width="60%" src="/img/active-resource-drill-down.png" />

--- a/docs/per_unit_costs.md
+++ b/docs/per_unit_costs.md
@@ -20,7 +20,7 @@ You must be an owner in order to import unit metrics. Anyone with Editor and abo
 
 There a different options for importing unit metrics. For each import you must specify the aggregation function to be used as these metrics will be aggregated to the day.
 
-### Importing from CloudWatch
+### Importing from CloudWatch {#importing-from-cloudwatch}
 
 To import Business Metrics from CloudWatch you need a specific metric name and AWS account. If Vantage does not have a Cross Account IAM Role for this account one will have to be created.
 
@@ -44,7 +44,7 @@ Each AWS service that you use will have its own metrics that it [sends to CloudW
 
 Metrics will be imported for the last 6 months. They will be automatically synced up on a daily basis along with cost data from other integrations. 
 
-### Importing from a CSV
+### Importing from a CSV {#importing-from-a-csv}
 
 You can upload a CSV in a specific two column format which can either replace existing data on upload or be used to import new data. You may supply up to 6 months worth of metrics.
 

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -29,7 +29,7 @@ Before you can connect your IdP to Vantage, you will need the following:
 - Owner role access to Vantage
 - Your IdP's signing certificate and sign-on URL
 
-### Connect Your SAML IdP
+### Connect Your SAML IdP {#enable-connection}
 
 1. From the Vantage console, navigate to the [Authentication page](https://console.vantage.sh/settings/account_identity_providers).
 2. Click **New Connection**.


### PR DESCRIPTION
This PR is to add anchor links to where sections are already referenced in the console or other pages. The practice as of recently has been to add an anchor link when a section is referenced for future-proofing if a section title is ever changed. 