### PR TITLE
Update css to be like main site

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -15,6 +15,7 @@
   --ifm-color-primary-lightest: #E59DFF;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-menu-color: #303037;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -155,7 +156,7 @@ li.theme-doc-sidebar-item-category-level-4 .menu__list-item-collapsible {
 
 .menu__list-item-collapsible .menu__link--active{
   background: none !important;
-  color: #606770;
+  color: #303037;
   font-weight: 700 !important;
 }
 


### PR DESCRIPTION
@EverettBerry 

Take a look and let me know what you think here. I updated the sidebar to be `#303037`. This is in line with what I see on the main site for the navigation links at the top. The links at the top of the docs site are `#5a5a5f`, which aligns with description text I see for containers on Integrations pages (e.g., https://www.vantage.sh/integrations/azure). I do like that lighter color at the top, but I can change it as well if you prefer. Let me know what you think. 