### PR TITLE
Update config for insights and links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,7 +22,7 @@ const config = {
   projectName: "docs.vantage.sh", // Usually your repo name.
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenMarkdownLinks: "throw",
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
@@ -146,6 +146,9 @@ const config = {
   
         // Optional: Algolia search parameters
         searchParameters: {},
+        
+        // Enables analytics 
+        insights: true,
   
         // Optional: path for search page that enabled by default (`false` to disable it)
         searchPagePath: 'search',


### PR DESCRIPTION
Putting as a PR to explain for posterity. Updated `docusaurus.config.js` options on the following:

- Set `insights: true` for Algolia to get click events
- Change `onBrokenMarkdownLinks: "warn",` to `onBrokenMarkdownLinks: "throw",` as `warn` was not stopping the build when Markdown links are broken, and `throw` should, in case I miss any