### PR TITLE
Add errors section for scheduling errors.

### DIFF
--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -217,11 +217,17 @@ Once changed, you can validate the change by looking for the scraping summary lo
 {"time":"2024-02-10T12:00:00.000000000Z","level":"INFO","msg":"finished scraping metrics from nodes","success":25,"failure":0,"duration_ms":102}
 ```
 
-### Pod Scheduling Errors
+### Pod Scheduling Errors {#pod-scheduling-errors}
 
-The most common cause for pod scheduling errors is the persistent volume not being provisioned. By default the agent is deployed as a StatefulSet with a persistent volume for persisting internal state. The state allows the agent to recover from a restart without losing the historical data for the current reporting window. An example error for this case would be present in the events on the `vka-vantage-kubernetes-agent-0` pod and include an error that contains `unbound immediate PersistentVolumeClaims`.
+The most common cause for pod scheduling errors is the persistent volume not being provisioned. By default, the agent is deployed as a StatefulSet with a persistent volume for persisting internal state. The state allows the agent to recover from a restart without losing the historical data for the current reporting window. An example error for this case would be present in the events on the `vka-vantage-kubernetes-agent-0` pod and include an error that contains `unbound immediate PersistentVolumeClaims`.
 
-Resolving this will be up to cluster configuration and specific cloud provider. More information might be present on the persistent volume claim or persistent volume. For kubernetes clusters on AWS, S3 can be used for data persistence and is documented below.
+The resolution to this error is based on the cluster's configuration and the specific cloud provider. More information might be present on the persistent volume claim or persistent volume. For Kubernetes clusters on AWS, S3 can be used for data persistence, which is documented in the next section. 
+
+Additional provider references are also listed here:
+
+- [GCP: Using the Compute Engine persistent disk CSI Driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver)
+- [Azure: Container Storage Interface (CSI) drivers on Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/csi-storage-drivers)
+- [AWS: Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)
 
 ## (Optional) Use S3 for Data Persistence
 

--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -217,6 +217,12 @@ Once changed, you can validate the change by looking for the scraping summary lo
 {"time":"2024-02-10T12:00:00.000000000Z","level":"INFO","msg":"finished scraping metrics from nodes","success":25,"failure":0,"duration_ms":102}
 ```
 
+### Pod Scheduling Errors
+
+The most common cause for pod scheduling errors is the persistent volume not being provisioned. By default the agent is deployed as a StatefulSet with a persistent volume for persisting internal state. The state allows the agent to recover from a restart without losing the historical data for the current reporting window. An example error for this case would be present in the events on the `vka-vantage-kubernetes-agent-0` pod and include an error that contains `unbound immediate PersistentVolumeClaims`.
+
+Resolving this will be up to cluster configuration and specific cloud provider. More information might be present on the persistent volume claim or persistent volume. For kubernetes clusters on AWS, S3 can be used for data persistence and is documented below.
+
 ## (Optional) Use S3 for Data Persistence
 
 The agent requires a persistent store for periodic backups of time-series data as well as checkpointing for periodic reporting. The default deployment option uses a Persistent Volume and works for clusters ranging from tens to thousands of nodes; however, if Persistent Volumes are not supported with your cluster, an alternative configuration, using S3, is available for agents deployed in AWS. If you require persistence to a different object store, you can contact [support@vantage.sh](mailto:support@vantage.sh).


### PR DESCRIPTION
Not sure how many we want to include for resolution, each cloud provider has its own steps to get persistent volumes working. I think these are the 3 most common approaches but there are a lot of other ways to go about it depending on how users administer their clusters.

https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver
https://learn.microsoft.com/en-us/azure/aks/csi-storage-drivers
https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html