### PR TITLE
fix: Correct helm value for persist s3.

### DIFF
--- a/docs/kubernetes_agent.md
+++ b/docs/kubernetes_agent.md
@@ -276,7 +276,7 @@ Below are the expected associated permissions for the IAM role:
 }
 ```
 
-Once the permissions are available, the agent can be configured to start with S3 persistence via the environment variable `VANTAGE_PERSIST_S3_BUCKET` or, if using the Helm chart, via the `--set persist=null --set persist_s3=example-bucket-name` values.
+Once the permissions are available, the agent can be configured to start with S3 persistence via the environment variable `VANTAGE_PERSIST_S3_BUCKET` or, if using the Helm chart, via the `--set persist=null --set persistS3.bucket=example-bucket-name` values.
 
 The agent will write persisted data to the `$CLUSTER_ID/` prefix within the bucket. Multiple agents can use the same bucket as long as they do not have overlapping `CLUSTER_ID` values. An optional prefix can be prepended with `VANTAGE_PERSIST_S3_PREFIX` resulting in `$VANTAGE_PERSIST_S3_PREFIX/$CLUSTER_ID/` being the prefix used by the agent for all objects uploaded.
 


### PR DESCRIPTION
Had my wires crossed. Double checked the documented commandline `--set` just to be sure.

```
➜  vantage-kubernetes-agent git:(main) helm template -n vantage vka . --set agent.token=foo,agent.clusterID=dev-custer --set persist=null --set persistS3.bucket=testing-bucket-name | grep -A2 "PERSIST_S3"
            - name: VANTAGE_PERSIST_S3_BUCKET
              value: "testing-bucket-name"
```