### PR TITLE
Update URL for Virtual Tagging

### DIFF
--- a/docs/active_resources.md
+++ b/docs/active_resources.md
@@ -91,7 +91,7 @@ Active resources are synced for each [workspace](/workspaces) at least once ever
 <div style={{display:"flex", justifyContent:"center"}}>
 <img alt="Resource Report Drill Down" width="100%" src="/img/resource.png" />
 </div>
-5. Any tags assigned to the resource (including [Virtual Tags](/virtual_tagging)) are also displayed in the **Assigned Tags** section at the bottom. 
+5. Any tags assigned to the resource (including [Virtual Tags](/tagging)) are also displayed in the **Assigned Tags** section at the bottom. 
 <div style={{display:"flex", justifyContent:"center"}}>
 <img alt="Assigned Tags on Resource Reports" width="100%" src="/img/assigned-tags.png" />
 </div>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,7 +65,7 @@ _See [September's update](/changelog#k8s-sept-24) for the most recent Kubernetes
 
 - **Update Dashboard order:** You now have the option to update the [report order](/dashboards#edit-dashboard-report-order) on Dashboards.
 - **AWS human-readable account names:** In addition to the account number, the human-readable account name is now visible on the [AWS Integrations](/connecting_aws) page for AWS account integrations.
-- **Virtual Tags processing status:** The "Processing..." indicator on [Virtual Tags](/virtual_tagging) now provides more accurate status updates, specifically for the initial run of new or updated Virtual Tag configurations.
+- **Virtual Tags processing status:** The "Processing..." indicator on [Virtual Tags](/tagging) now provides more accurate status updates, specifically for the initial run of new or updated Virtual Tag configurations.
 - **Virtual Tags in Resource Reports:** You can now [filter by Virtual Tags](/active_resources#resource-report-filters) within Resource Report filters.
 - **Linode integration:** Vantage now integrates with [Linode from Akamai Connected Cloud](/connecting_linode) as its latest cost provider.
 - **Integration Owner role:** The new [Integration Owner role](/rbac) has all the privileges of the Editor role, as well as the ability to configure and manage access to provider integrations. The role does not have access to other sensitive configuration settings.
@@ -187,7 +187,7 @@ _See [May's update](/changelog#may-24-k8s) for the most recent Kubernetes agent 
 
 ### Product Updates
 
-- **Dynamic Cost Allocation:** Dynamic cost allocation, which is the process of allocating costs based on another existing cost or metric, is now available. See the [Virtual Tagging](/virtual_tagging) documentation for details.
+- **Dynamic Cost Allocation:** Dynamic cost allocation, which is the process of allocating costs based on another existing cost or metric, is now available. See the [Virtual Tagging](/tagging) documentation for details.
 - **Workspace access updates:** If you are granted access via [RBAC](/rbac) to a report in a workspace outside your regularly accessed workspace, when you access the link to the report, you will have temporary access to the new workspace and can view the items that you were granted access to.
 - **Share reports across workspaces:** You can now share report links across different [workspaces](/workspaces). For example, if you're in Workspace A and open a report link from Workspace B, you'll be automatically switched to Workspace B to view the report. Previously, a `404` error was displayed.
 - **GCP active resources:** [GCP active resources](/gcp_supported_services) are now synced and available to filter within Resource Reports.
@@ -277,7 +277,7 @@ New `/integrations` [endpoints](https://vantage.readme.io/reference/createazurei
 
 - **Visual navigation improvements:** A **Create New** menu for quick actions is available on the top navigation bar.
 - **Datadog metrics:** Business metrics have been updated with the option to directly ingest [Datadog metrics](/per_unit_costs#importing-from-datadog).
-- **New virtual tagging feature:** [Virtual tagging](/virtual_tagging) is available to consistently tag costs across providers in Vantage. This feature can help to increase tagging coverage across your cloud infrastructure.
+- **New virtual tagging feature:** [Virtual tagging](/tagging) is available to consistently tag costs across providers in Vantage. This feature can help to increase tagging coverage across your cloud infrastructure.
 - **New rightsizing recommendations:** Kubernetes [rightsizing recommendations](/cost_recommendations#kubernetes-rightsizing) are now available for rightsizing managed workloads in Kubernetes.
 - **New to active resources:** Kubernetes managed workloads are synced as [active resources](/active_resources) in Vantage.
 - **Expanded forecasts:** [Forecasts](/forecasting) have been expanded to include the upcoming month, the next three months, and six months ahead.
@@ -296,7 +296,7 @@ _See [March's update](/changelog#kubernetes-agent-updates-1) for the most recent
   - The [`/financial_commitment_reports`](https://vantage.readme.io/reference/getfinancialcommitmentreports) endpoint automates the retrieval of [financial commitment reports](/financial_commitment_reports).
   - The [`/kubernetes_efficiency_reports`](https://vantage.readme.io/reference/getkubernetesefficiencyreports) endpoint automates the retrieval of [Kubernetes efficiency reports](/kubernetes).
   - The [`/anomaly_alerts`](https://vantage.readme.io/reference/getanomalyalerts) endpoint allows you to retrieve and update [anomaly alerts](/cost_anomaly_alerts).
-  - The [`/virtual_tag_configs`](https://vantage.readme.io/reference/createvirtualtagconfig) endpoint automates the creation, retrieval, and update of [virtual tags](/virtual_tagging).
+  - The [`/virtual_tag_configs`](https://vantage.readme.io/reference/createvirtualtagconfig) endpoint automates the creation, retrieval, and update of [virtual tags](/tagging).
   - The [`/anomaly_notifications`](https://vantage.readme.io/reference/createanomalynotification) endpoint automates the creation, retrieval, and update of anomaly notifications.
   - The [`/budgets`](https://vantage.readme.io/reference/createbudget) endpoint automates the creation, retrieval, and update of [budgets](/budgets).
   - The [`/budgets_alerts`](https://vantage.readme.io/reference/createbudgetalert) endpoint automates the creation, retrieval, and update of budgets alerts.

--- a/docs/connecting_aws.md
+++ b/docs/connecting_aws.md
@@ -156,7 +156,7 @@ On AWS [Cost Reports](/cost_reports), you can filter across several dimensions:
 
 - Account (AWS account name)
 - Category (e.g., EC2 Data Transfer)
-- Tag/Not Tagged (includes AWS tags and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag/Not Tagged (includes AWS tags and [virtual tags](/tagging) created in Vantage for this provider)
 - Subcategory (e.g., EC2 DataTransfer-In-Bytes)
 - Resource (specific resource IDs)
 - Region (e.g., US East (Ohio))

--- a/docs/connecting_azure.md
+++ b/docs/connecting_azure.md
@@ -188,7 +188,7 @@ On Azure [Cost Reports](/cost_reports), you can filter across several dimensions
 
 - Resource Group (resource group name)
 - Category (e.g., Virtual Network IP Addresses)
-- Tag/Not Tagged (includes Azure tags and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag/Not Tagged (includes Azure tags and [virtual tags](/tagging) created in Vantage for this provider)
 - Subcategory (e.g., Virtual Network Standard IPv4 Static Public IP)
 - Resource (resource ID)
 - Region (e.g., Us East)

--- a/docs/connecting_confluent.md
+++ b/docs/connecting_confluent.md
@@ -64,7 +64,7 @@ See the [provider data refresh documentation](/provider_data_refresh) for inform
 On Confluent [Cost Reports](/cost_reports/), you can filter costs across several dimensions:
 
 - Category (e.g., Kafka Storage)
-- Tag ([virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([virtual tags](/tagging) created in Vantage for this provider)
 - Resource (resource service ID)
 - Charge Type (e.g., Usage)
 - Organization (organization ID)

--- a/docs/connecting_coralogix.md
+++ b/docs/connecting_coralogix.md
@@ -77,7 +77,7 @@ On Coralogix [Cost Reports](/cost_reports/), you can filter costs across several
 - Service (e.g., Logs, Metrics, Spans)
 - Category (subsystem name)
 - Subcategory (application name)
-- Tag ([virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([virtual tags](/tagging) created in Vantage for this provider)
 
 :::note
 Because the Metrics service doesn’t have a subsystem or application name, costs for this service can't be filtered by category or subcategory.

--- a/docs/connecting_databricks.md
+++ b/docs/connecting_databricks.md
@@ -114,7 +114,7 @@ On Databricks [Cost Reports](/cost_reports/), you can filter across several dime
 
 - Account (account name)
 - Category (e.g., Jobs Compute - Photon)
-- Tag/Not Tagged (includes Databricks tags and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag/Not Tagged (includes Databricks tags and [virtual tags](/tagging) created in Vantage for this provider)
 - Cluster (e.g., Jobs Compute - `<CLUSTER_ID>`)
 - Charge Type (e.g., Usage)
 - Service (e.g., All Purpose Compute)

--- a/docs/connecting_datadog.md
+++ b/docs/connecting_datadog.md
@@ -136,7 +136,7 @@ On Datadog [Cost Reports](/cost_reports), you can filter across several dimensio
 
 - Organization (organization name)
 - Category (e.g., APM integrated spans)
-- Tag/Not Tagged (includes Datadog tags and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag/Not Tagged (includes Datadog tags and [virtual tags](/tagging) created in Vantage for this provider)
 - Subcategory (e.g., Virtual Network Standard IPv4 Static Public IP)
 - Charge Type (e.g., Usage)
 - Service (e.g., Database Monitoring)

--- a/docs/connecting_fastly.md
+++ b/docs/connecting_fastly.md
@@ -58,4 +58,4 @@ On Fastly [Cost Reports](/cost_reports), you can filter across several dimension
 - Region (e.g., Usa)
 - Charge Type (e.g., Usage)
 - Service (e.g., CDN)
-- Tag ([virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([virtual tags](/tagging) created in Vantage for this provider)

--- a/docs/connecting_gcp.md
+++ b/docs/connecting_gcp.md
@@ -138,7 +138,7 @@ On GCP [Cost Reports](/cost_reports), you can filter across several dimensions:
 
 - Project (project name)
 - Category (e.g., Cloud Functions Invocations (2nd Gen))
-- Label/Not Labeled (includes GCP labels and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Label/Not Labeled (includes GCP labels and [virtual tags](/tagging) created in Vantage for this provider)
 - Resource (resource ID)
 - Region (e.g., Us East1)
 - Charge Type (e.g., Usage)

--- a/docs/connecting_github.md
+++ b/docs/connecting_github.md
@@ -155,7 +155,7 @@ See the [provider data refresh documentation](/provider_data_refresh) for inform
 On GitHub [Cost Reports](/cost_reports/), you can filter costs across several dimensions:
 
 - Category (e.g., Actions - Hosted Runner)
-- Tag (Includes the below items and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag (Includes the below items and [virtual tags](/tagging) created in Vantage for this provider)
   - owner
   - repo
   - username
@@ -173,7 +173,7 @@ You can also view GitHub credits in Cost Reports.
 
 ## GitHub Costs Demonstration
 
-The below video talks about how to get started with GitHub costs and how to use [Virtual Tags](/virtual_tagging) along with this integration.
+The below video talks about how to get started with GitHub costs and how to use [Virtual Tags](/tagging) along with this integration.
 
 <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0 }}>
     <iframe src="https://www.youtube.com/embed/npyZQRlTuGY?si=AtCe7H23BvYFsZsB?rel=0&color=white&modestbranding=1&showinfo=0&wmode=transparent" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen="true" style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', borderRadius: '10px' }}></iframe>

--- a/docs/connecting_kubernetes.md
+++ b/docs/connecting_kubernetes.md
@@ -41,7 +41,7 @@ See the [provider data refresh documentation](/provider_data_refresh) for inform
 On Kubernetes [Cost Reports](/cost_reports), you can filter across several dimensions:
 
 - Account (associated account name)
-- Grouping (includes Kubernetes grouping names and values and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Grouping (includes Kubernetes grouping names and values and [virtual tags](/tagging) created in Vantage for this provider)
 - Region (e.g., Westus2)
 - Charge Type (e.g., Usage)
 - Cluster (cluster name)

--- a/docs/connecting_linode.md
+++ b/docs/connecting_linode.md
@@ -78,7 +78,7 @@ On Linode [Cost Reports](/cost_reports/), you can filter costs across several di
 
 - Category (e.g., Linode Instance - Compute)
 - Subcategory (e.g., Linode Instance - Dedicated 16GB)
-- Tag ([Virtual Tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([Virtual Tags](/tagging) created in Vantage for this provider)
 - Resource (e.g., specific resource names)
 - Charge Type (e.g., Usage or Discount)
 - Service (e.g., Node Balancer)

--- a/docs/connecting_mongodb-atlas.md
+++ b/docs/connecting_mongodb-atlas.md
@@ -147,7 +147,7 @@ On MongoDB Atlas [Cost Reports](/cost_reports), you can filter across several di
 
 - Project (project ID)
 - Category (Atlas Cluster - Atlas Instance M2)
-- Tag (includes MongoDB tags and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag (includes MongoDB tags and [virtual tags](/tagging) created in Vantage for this provider)
 - Resource (service resource ID)
 - Charge Type (e.g., Usage)
 - Organization (organization name)

--- a/docs/connecting_new_relic.md
+++ b/docs/connecting_new_relic.md
@@ -43,6 +43,6 @@ On New Relic [Cost Reports](/cost_reports), you can filter across several dimens
 
 - Account (account name)
 - Category (e.g., New Relic Users - CoreUsers)
-- Tag ([virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([virtual tags](/tagging) created in Vantage for this provider)
 - Charge Type (e.g., Usage)
 - Service (e.g., New Relic Ingestion)

--- a/docs/connecting_oracle.md
+++ b/docs/connecting_oracle.md
@@ -39,7 +39,7 @@ On Oracle [Cost Reports](/cost_reports), you can filter across several dimension
 
 - Compartment
 - Category (e.g., MYSQL - MySQL Database Service - Standard - AMD E4 - Memory)
-- Tag/Not Tagged (includes Oracle tags and [virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag/Not Tagged (includes Oracle tags and [virtual tags](/tagging) created in Vantage for this provider)
 - Resource (resource ID)
 - Region (e.g., Us Ashburn 1)
 - Charge Type (e.g., Usage)

--- a/docs/connecting_planetscale.md
+++ b/docs/connecting_planetscale.md
@@ -64,7 +64,7 @@ See the [provider data refresh documentation](/provider_data_refresh) for inform
 On PlanetScale [Cost Reports](/cost_reports/), you can filter costs across several dimensions:
 
 - Category (e.g., PS-10, PS-20)
-- Tag ([virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([virtual tags](/tagging) created in Vantage for this provider)
 - Resource (e.g., database name)
 - Charge Type (e.g., Usage)
 - Organization (organization ID)

--- a/docs/connecting_snowflake.md
+++ b/docs/connecting_snowflake.md
@@ -136,7 +136,7 @@ On Snowflake [Cost Reports](/cost_reports), you can filter across several dimens
 - Region (e.g., AWS Eu West 1)
 - Organization (organization name)
 - Service (e.g., Data Cloud)
-- Tag ([virtual tags](/virtual_tagging) created in Vantage for this provider)
+- Tag ([virtual tags](/tagging) created in Vantage for this provider)
 - Charge Type (e.g., Usage)
 
 ## Active Resources 

--- a/docs/cost_reports.md
+++ b/docs/cost_reports.md
@@ -156,7 +156,7 @@ You can group by the following dimensions:
 - Subcategory
 - Charge Type (see the [section below](/cost_reports#charge-type) for definitions)
 - Tagged (e.g., see whether resources are or are not tagged)
-- Tag (includes [virtual tags](/virtual_tagging))
+- Tag (includes [virtual tags](/tagging))
 
 After a Cost Report has been grouped, each grouping is displayed as a column in the table below the graph. On the graph itself, group labels are displayed with dashes between each grouping, such as `production - Acme - nat-123456`.
 

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -1,5 +1,5 @@
 ---
-id: virtual_tagging
+id: tagging
 name: Virtual Tagging
 description: Create virtual tags within Vantage to provide a consistent tagging schema across cloud providers.
 keywords:
@@ -37,7 +37,7 @@ If you want to transition any of your cost allocation segments to virtual tags, 
 
 With custom value tags, you can create new cross-provider cost allocation tags to help better your tagging strategy. For example, you may have a series of resource tags, by product, across each of your providers. You can create custom tags in Vantage to combine those costs into one unique product tag for all resources in that product group.
 
-See the [example section](/virtual_tagging#custom-values-example) below for details.
+See the [example section](/tagging#custom-values-example) below for details.
 
 ## Cost-Based and Business Metrics-Based Allocation Tags
 
@@ -55,13 +55,13 @@ The cost-based and business metrics-based allocation tag types allow for _dynami
 
 With cost-based allocation tags, you can create a dynamically allocated cost structure. Select a set of input costs (e.g., all AWS costs), an existing cost tag to use for allocation (e.g., a teams cost tag), and an output cost (e.g, a static cost, like AWS Support) that you want to be allocated the same way as your input cost.
 
-See the [example section](/virtual_tagging#cost-based-allocation-example) below for details.
+See the [example section](/tagging#cost-based-allocation-example) below for details.
 
 ### Business Metrics-Based Allocation Tags
 
 With business metrics-based allocation tags, you select an existing [business metric](/per_unit_costs) (e.g., CPU use per product) and indicate your output cost (e.g., all GCP Compute costs) so that the allocation of the output cost mimics the percentage allocation of the existing business metric.
 
-See the [example section](/virtual_tagging#metric-based-allocation-example) below for details.
+See the [example section](/tagging#metric-based-allocation-example) below for details.
 
 ## Create Virtual Tags
 

--- a/docs/usage_based_reporting.md
+++ b/docs/usage_based_reporting.md
@@ -68,7 +68,7 @@ If a provider does not have usage data, the Usage Unit column is empty and the A
 
 ## Use Virtual Tags with Usage-Based Reporting
 
-[Virtual Tags](https://docs.vantage.sh/virtual_tagging) work across both cost and usage consumption for supported providers. If you created Virtual Tags based on cost, the associated usage consumption will inherit the same Virtual Tag. You can use Virtual Tags within your filter criteria to apply Virtual Tags based on usage.
+[Virtual Tags](https://docs.vantage.sh/tagging) work across both cost and usage consumption for supported providers. If you created Virtual Tags based on cost, the associated usage consumption will inherit the same Virtual Tag. You can use Virtual Tags within your filter criteria to apply Virtual Tags based on usage.
 
 ## Usage-Based Reporting on Dashboards {#dashboards}
 

--- a/docs/vantage_university_cost_allocation.md
+++ b/docs/vantage_university_cost_allocation.md
@@ -54,7 +54,7 @@ As a **cloud operations manager**, you can:
 ## 📖 Additional Resources
 
 - [Role-Based Access Control](/rbac)
-- [Create Virtual Tags](/virtual_tagging#create-virtual-tags)
-- [Virtual Tagging Examples](/virtual_tagging#virtual-tagging-examples)
+- [Create Virtual Tags](/tagging#create-virtual-tags)
+- [Virtual Tagging Examples](/tagging#virtual-tagging-examples)
 - [Create a Segment](/segments#create-a-segment)
 - [View and Create Child Segments](/segments#view-and-create-child-segments)

--- a/docs/vantage_university_finance_manager.md
+++ b/docs/vantage_university_finance_manager.md
@@ -58,8 +58,8 @@ See the following resources to help you get started with Virtual Tags, dynamic c
 <details><summary>Click to view resources</summary>
 
 - [Vantage University Cost Allocation](/vantage_university_cost_allocation)
-- [Create Virtual Tags](/virtual_tagging#create-virtual-tags)
-- [Virtual Tagging Examples](/virtual_tagging#examples)
+- [Create Virtual Tags](/tagging#create-virtual-tags)
+- [Virtual Tagging Examples](/tagging#examples)
 - [Create a Segment](/segments#create-a-segment)
 - [View and Create Child Segments](/segments#view-and-create-child-segments)
 

--- a/docs/vantage_university_finops_analyst.md
+++ b/docs/vantage_university_finops_analyst.md
@@ -58,8 +58,8 @@ See the following resources to help you get started with Virtual Tags, dynamic c
 <details><summary>Click to view resources</summary>
 
 - [Vantage University Cost Allocation](/vantage_university_cost_allocation)
-- [Create Virtual Tags](/virtual_tagging#create-virtual-tags)
-- [Virtual Tagging Examples](/virtual_tagging#examples)
+- [Create Virtual Tags](/tagging#create-virtual-tags)
+- [Virtual Tagging Examples](/tagging#examples)
 - [Create a Segment](/segments#create-a-segment)
 - [View and Create Child Segments](/segments#view-and-create-child-segments)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,6 +119,10 @@ const config = {
             from: "/kubernetes_container_insights",
             to: "/kubernetes_agent",
           },
+          {
+            from: "/virtual_tagging",
+            to: "/tagging",
+          },
         ],
       },
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -64,7 +64,7 @@ module.exports = {
         "sso",
         "rbac",
         "workspaces",
-        "virtual_tagging",
+        "tagging",
       ],
     },
     {


### PR DESCRIPTION
Changes from /virtual_tagging to /tagging to accommodate all tagging types. Page will have sections for all types.