### PR TITLE
Add Organization to GitHub data dictionary

### DIFF
--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -195,16 +195,17 @@ _\* Virtual tags associated with this provider_
 
 ## GitHub {#github}
 
-| Filter      | API Field Name | Data Type | `namespace.field`   |
-| ----------- | -------------- | --------- | ------------------- |
-| Service     | `service`      | string    | `costs.service`     |
-| Provider    | `provider`     | string    | `costs.provider`    |
-| Category    | `category`     | string    | `costs.category`    |
-| Subcategory | `subcategory`  | string    | `costs.subcategory` |
-| Resource    | `resource_id`  | string    | `costs.resource_id` |
-| Charge Type | `charge_type`  | string    | `costs.charge_type` |
-| Tag         | `name`         | string    | `tags.name`         |
-| Tag Value   | `value`        | string    | `tags.value`        |
+| Filter       | API Field Name        | Data Type | `namespace.field`           |
+| -----------  | --------------------- | --------- | --------------------------- |
+| Organization | `provider_account_id` | string    | `costs.provider_account_id` |
+| Service      | `service`             | string    | `costs.service`             |
+| Provider     | `provider`            | string    | `costs.provider`            |
+| Category     | `category`            | string    | `costs.category`            |
+| Subcategory  | `subcategory`         | string    | `costs.subcategory`         |
+| Resource     | `resource_id`         | string    | `costs.resource_id`         |
+| Charge Type  | `charge_type`         | string    | `costs.charge_type`         |
+| Tag          | `name`                | string    | `tags.name`                 |
+| Tag Value    | `value`               | string    | `tags.value`                |
 
 ## Google Cloud {#google-cloud-platform}
 


### PR DESCRIPTION
The GitHub data dictionary was missing `Organization`.

![image](https://github.com/user-attachments/assets/bcbd7d7b-7abd-4961-a63d-3abaff4845c2)
